### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Generating a new Project
 - Install php
 
   ```bash
-  $ brew install php56 --with-pdo-pgsql
+  $ brew install php
   ```
 
 Using the Generated Project

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To begin working with the project
 
 ## Getting Started
 - run `npm install` to install application development dependencies
+  - **Ensure that node version 4.2.4 is being used**, so that the right `Util/util` is downloaded to node_modules
 - configure the application
 - run `grunt` from the install directory
 


### PR DESCRIPTION
A couple updates to the README,
 - The brew tap for `php56 --with-pdo-pgsql` no longer exists
 - Need to be careful when running `npm install` on this project with an node version of 4+. That causes the project to bundle the wrong `Util/util` package